### PR TITLE
Update tests to not make strong assumptions about actionButton()'s ma…

### DIFF
--- a/tests/testthat/test-add_prompt.R
+++ b/tests/testthat/test-add_prompt.R
@@ -3,9 +3,9 @@ test_that("add_prompt adds info as attributes of the element if not an image", {
   x <- shiny::actionButton("test", "test")
   y <- add_prompt(x, message = "foo")
 
-  expect_equal(
-    as.character(y),
-    '<button aria-label="foo" class="btn btn-default action-button hint--bottom" id="test" type="button">test</button>'
+  expect_match(
+    htmltools::tagGetAttribute(y, "class"),
+    'hint--bottom'
   )
 
 })
@@ -34,9 +34,9 @@ test_that("options are in the right form", {
   x <- shiny::actionButton("test", "test")
   y <- add_prompt(x, message = "foo", bounce = TRUE, animate = FALSE)
 
-  expect_equal(
-    as.character(y),
-    '<button aria-label="foo" class="btn btn-default action-button hint--bottom hint--bounce hint--no-animate" id="test" type="button">test</button>'
+  expect_match(
+    htmltools::tagGetAttribute(y, "class"),
+    'hint--bottom hint--bounce hint--no-animate'
   )
 
 })


### PR DESCRIPTION
Hello, I'm a core contributor to Shiny, and this PR is in anticipation for https://github.com/rstudio/shiny/pull/4249, where we plan on making changes to the HTML markup that `actionButton()` produces, which will break these tests.

I've updated your tests to still test the logic your aiming to test, but without making such strong assumptions about the markup that `actionButton()` generates. If you could submit these changes to CRAN in the somewhat near future, that'd be greatly appreciated. Thanks!